### PR TITLE
Updated version of credstash, for hmac buffer support

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "babel-runtime": "6.23.0",
-    "credstash": "1.0.42",
+    "credstash": "1.0.44",
     "deasync-promise": "1.0.1",
     "lodash": "4.17.4",
     "winston": "2.3.1"


### PR DESCRIPTION
Credstash is getting the hmac back from Dynamo DB as a buffer, but the current version being used expects a string.  The new version checks if it is a string, and if not treats it as a buffer,